### PR TITLE
Change code example formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ A plugin that adds some project management utilities.
 Make a code block and use `gantt` as the style.
 In the block, write your Dataview query
 
-```sh
-\```gantt
+~~~sh
+```gantt
 #project/tasks
-\```
 ```
+~~~
 
 ## Notes
 


### PR DESCRIPTION
Whenever we want to show MD examples we can use alternative code separators `~` - triple tilde character.